### PR TITLE
fix_refactor: 予約時間の重複検証機能の修正とバリデーション内容の更新及び表示に関するリファクタリング.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@
 
 - 編集完了
 
-### アラートコード
-- 予約内容の時間帯が競合した場合に表示されるアラート情報の発生元ファイル
-  - aCode:001<br>`src\app\components\schedule\todoItems\TodoForm.tsx`
-  - aCode:002<br>`src\app\components\schedule\todoItems\utils\TodoFormItemTimeSchedule.tsx`
-  - aCode:003<br>`src\app\components\schedule\todoItems\utils\TodoFormItemRegiBtn.tsx`
+---
 
 ## 技術構成
 - @prisma/client@6.4.0

--- a/src/app/components/schedule/todoItems/TodoForm.tsx
+++ b/src/app/components/schedule/todoItems/TodoForm.tsx
@@ -13,7 +13,6 @@ import { useRegiTodoItem } from "./hooks/useRegiTodoItem";
 import { useUpdateTodoItem } from "./hooks/useUpdateTodoItem";
 import { useScrollTop } from "@/app/hooks/useScrollTop";
 import { useHandleFormItems } from "./hooks/useHandleFormItems";
-import { useCheckTimeBlockEntryForm } from "./hooks/useCheckTimeBlockEntryForm";
 
 type TodoFormType = {
     todoItem?: todoItemType;
@@ -24,7 +23,9 @@ function TodoForm({ props }: { props: TodoFormType }) {
     const { todoItem, todoId } = props;
 
     const [rooms] = useAtom(roomsAtom);
+
     const roomRef = useRef<null | HTMLSelectElement>(null);
+    const validationTxtRef = useRef<string>('');
 
     const initTodoItems: todoItemType = {
         id: todoItem ? todoItem.id : '001',
@@ -43,7 +44,6 @@ function TodoForm({ props }: { props: TodoFormType }) {
     const { updateTodoItem } = useUpdateTodoItem();
     const { scrollTop } = useScrollTop();
     const { handleOpenClosedBtnClicked } = useHandleFormItems();
-    const { checkDuplicateTimeSchedule } = useCheckTimeBlockEntryForm();
 
     const resetStates: () => void = () => {
         setTodoItems(initTodoItems);
@@ -53,12 +53,6 @@ function TodoForm({ props }: { props: TodoFormType }) {
     return (
         <form className={todoStyle.todoForm} onSubmit={(formElm: ChangeEvent<HTMLFormElement>) => {
             formElm.preventDefault();
-            const isCheckDuplicateTime: boolean = checkDuplicateTimeSchedule(todoItems);
-            if (isCheckDuplicateTime) {
-                alert('希望予約時間が他の予定と重複しています | aCode:001');
-                return;
-            }
-
             if (!todoItems.edit) {
                 regiTodoItem(todoItems);
                 handleOpenClosedBtnClicked(formElm);
@@ -74,16 +68,16 @@ function TodoForm({ props }: { props: TodoFormType }) {
             <TodoFormItemPerson todoItems={todoItems} setTodoItems={setTodoItems} />
 
             {/* 予約室 */}
-            <TodoFormItemRoom rooms={rooms} todoItems={todoItems} setTodoItems={setTodoItems} roomRef={roomRef} />
+            <TodoFormItemRoom rooms={rooms} todoItems={todoItems} setTodoItems={setTodoItems} roomRef={roomRef} validationTxtRef={validationTxtRef} />
 
             {/* タイムテーブル（スケジュール）*/}
-            <TodoFormItemTimeSchedule todoItems={todoItems} setTodoItems={setTodoItems} />
+            <TodoFormItemTimeSchedule todoItems={todoItems} setTodoItems={setTodoItems} validationTxtRef={validationTxtRef} />
 
             {/* パスワード */}
             <TodoFormItemPassword todoItems={todoItems} setTodoItems={setTodoItems} />
 
             {/* 登録ボタン */}
-            <TodoFormItemRegiBtn todoItems={todoItems} resetStates={resetStates} />
+            <TodoFormItemRegiBtn todoItems={todoItems} resetStates={resetStates} validationTxtRef={validationTxtRef} />
         </form>
     );
 }

--- a/src/app/components/schedule/todoItems/hooks/useCheckTimeValidation.ts
+++ b/src/app/components/schedule/todoItems/hooks/useCheckTimeValidation.ts
@@ -1,0 +1,44 @@
+import { RefObject } from "react";
+import { todoItemType } from "../ts/todoItemType";
+import { timeBlockBegin, timeBlockEnd } from "@/app/types/rooms-atom";
+import { useCheckTimeBlockEntryForm } from "./useCheckTimeBlockEntryForm";
+
+export const useCheckTimeValidation = () => {
+    const { checkTimeBlockEntryForm, checkTimeSchedule } = useCheckTimeBlockEntryForm();
+
+    const checkTimeValidation: (todoItems: todoItemType, validationTxtRef?: RefObject<string>) => void = (
+        todoItems: todoItemType,
+        validationTxtRef?: RefObject<string>
+    ) => {
+        if (
+            (typeof todoItems.startTime !== 'undefined' && typeof todoItems.finishTime !== 'undefined') &&
+            typeof validationTxtRef !== 'undefined'
+        ) {
+            const isCheckTimeBlockEntryForm_start: boolean = checkTimeBlockEntryForm(todoItems.startTime);
+            const isCheckTimeBlockEntryForm_finish: boolean = checkTimeBlockEntryForm(todoItems.finishTime);
+            if (isCheckTimeBlockEntryForm_start || isCheckTimeBlockEntryForm_finish) {
+                validationTxtRef.current = `「${timeBlockBegin}時〜${timeBlockEnd}時」の時間帯で指定してください`;
+            }
+
+            const isCheckTimeSchedule_start: boolean = checkTimeSchedule(todoItems.startTime, todoItems);
+            const isCheckTimeSchedule_finish: boolean = checkTimeSchedule(todoItems.finishTime, todoItems);
+            if (isCheckTimeSchedule_start || isCheckTimeSchedule_finish) {
+                validationTxtRef.current = '他の方が既に予約済みです';
+            }
+
+            const isCheckTimeBlockEntryForm_FALSE: boolean = !isCheckTimeBlockEntryForm_start && !isCheckTimeBlockEntryForm_finish;
+            const isCheckTimeSchedule_FALSE: boolean = !isCheckTimeSchedule_start && !isCheckTimeSchedule_finish;
+
+            // バリデーションの初期化（ useCheckTimeBlockEntryForm の上記どちらの関数処理チェックも false かつ validationTxtRef が入力済みの場合）
+            if (
+                isCheckTimeBlockEntryForm_FALSE &&
+                isCheckTimeSchedule_FALSE &&
+                validationTxtRef.current.length > 0
+            ) {
+                validationTxtRef.current = '';
+            }
+        }
+    }
+
+    return { checkTimeValidation }
+}

--- a/src/app/components/schedule/todoItems/styles/todoStyle.module.css
+++ b/src/app/components/schedule/todoItems/styles/todoStyle.module.css
@@ -6,6 +6,25 @@
     line-height: 1.8;
 }
 
+.todoForm {
+    position: relative;
+}
+
+.formBtns {
+    & span {
+        display: block;
+        width: 100%;
+        position: absolute;
+        transform: translate(-50%, -50%);
+        top: 100%;
+        left: 50%;
+        padding: 1em;
+        background-color: #cc3226;
+        color: #fff;
+        border-radius: 4px;
+    }
+}
+
 & .todoView {
     & .today {
         font-size: 2.4rem;

--- a/src/app/components/schedule/todoItems/utils/TodoFormItemRoom.tsx
+++ b/src/app/components/schedule/todoItems/utils/TodoFormItemRoom.tsx
@@ -1,15 +1,20 @@
-import { ChangeEvent, Dispatch, Ref, memo, SetStateAction } from "react";
+import { ChangeEvent, Dispatch, Ref, memo, SetStateAction, RefObject } from "react";
 import { todoItemType } from "../ts/todoItemType";
 import { roomsType } from "@/app/components/rooms/ts/roomsType";
 import { useHandleFormEntries } from "@/app/hooks/useHandleFormEntries";
+import { useCheckTimeValidation } from "../hooks/useCheckTimeValidation";
 
-function TodoFormItemRoom({ rooms, todoItems, setTodoItems, roomRef }: {
+function TodoFormItemRoom({ rooms, todoItems, setTodoItems, roomRef, validationTxtRef }: {
     rooms: roomsType,
     todoItems: todoItemType,
     setTodoItems: Dispatch<SetStateAction<todoItemType>>,
-    roomRef: Ref<HTMLSelectElement> | undefined
+    roomRef: Ref<HTMLSelectElement> | undefined,
+    validationTxtRef?: RefObject<string>
 }) {
     const { handleFormEntries } = useHandleFormEntries();
+
+    const { checkTimeValidation } = useCheckTimeValidation();
+    checkTimeValidation(todoItems, validationTxtRef);
 
     return (
         <>

--- a/src/app/components/schedule/todoItems/utils/TodoFormItemTimeSchedule.tsx
+++ b/src/app/components/schedule/todoItems/utils/TodoFormItemTimeSchedule.tsx
@@ -1,30 +1,19 @@
 import todoStyle from "../styles/todoStyle.module.css";
-import { ChangeEvent, Dispatch, memo, SetStateAction } from "react";
-import { timeBlockBegin, timeBlockEnd } from "@/app/types/rooms-atom";
+import { ChangeEvent, Dispatch, memo, RefObject, SetStateAction } from "react";
 import { todoItemType } from "../ts/todoItemType";
+import { useCheckTimeValidation } from "../hooks/useCheckTimeValidation";
 import { useHandleFormEntries } from "@/app/hooks/useHandleFormEntries";
-import { useCheckTimeBlockEntryForm } from "@/app/components/schedule/todoItems/hooks/useCheckTimeBlockEntryForm";
 
-function TodoFormItemTimeSchedule({ todoItems, setTodoItems }: {
+function TodoFormItemTimeSchedule({ todoItems, setTodoItems, validationTxtRef }: {
     todoItems: todoItemType,
-    setTodoItems: Dispatch<SetStateAction<todoItemType>>
+    setTodoItems: Dispatch<SetStateAction<todoItemType>>,
+    validationTxtRef?: RefObject<string>
 }) {
+    const { checkTimeValidation } = useCheckTimeValidation();
     const { handleFormEntries } = useHandleFormEntries();
-    const { checkTimeBlockEntryForm, checkTimeSchedule } = useCheckTimeBlockEntryForm();
 
     const handleTimeSchedule: (e: ChangeEvent<HTMLInputElement>) => void = (e: ChangeEvent<HTMLInputElement>) => {
-        const isCheckTimeBlockEntryForm: boolean = checkTimeBlockEntryForm(e);
-        if (isCheckTimeBlockEntryForm) {
-            alert(`「${timeBlockBegin}時〜${timeBlockEnd}時」の時間帯で指定してください`);
-            return;
-        }
-
-        const isCheckTimeSchedule: boolean = checkTimeSchedule(e, todoItems);
-        if (isCheckTimeSchedule) {
-            alert('他の方が既に予約済みです | aCode:002');
-            return;
-        }
-
+        checkTimeValidation(todoItems, validationTxtRef);
         handleFormEntries<todoItemType>(e, todoItems, setTodoItems);
     }
 


### PR DESCRIPTION
- 予約時間の重複検証機能の修正
  - `src/app/components/schedule/todoItems/hooks/useCheckTimeBlockEntryForm.ts`
- バリデーション内容の更新及び表示に関するリファクタリング（※従来のアラート表示を廃止）
  - `src/app/components/schedule/todoItems/TodoForm.tsx`<br>`useRef`を利用してバリデーションテキストを（再レンダリングしない形で）管理
    - `src/app/components/schedule/todoItems/utils/TodoFormItemRegiBtn.tsx`<br>`ref`を受け取った処理の実装及びリファクタリング
    - `src/app/components/schedule/todoItems/utils/TodoFormItemRoom.tsx`<br>※`TodoFormItemRegiBtn`と同内容の修正
    - `src/app/components/schedule/todoItems/utils/TodoFormItemTimeSchedule.tsx`<br>※`TodoFormItemRegiBtn`と同内容の修正
  - `src/app/components/schedule/todoItems/hooks/useCheckTimeValidation.ts`<br>バリデーションテキストの内容管理に関する処理をカスタムフックとして分割
  - `src/app/components/schedule/todoItems/styles/todoStyle.module.css`<br>従来のアラート表示からバリデーションテキストの表示仕様に変更したのでバリデーション要素へのスタイルを指定
- ドキュメントの更新<br>`README.md`